### PR TITLE
Make prizes optional.

### DIFF
--- a/reclama/sprints/migrations/0004_prize_optional.py
+++ b/reclama/sprints/migrations/0004_prize_optional.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sprints', '0003_event_text'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='bug',
+            name='prize',
+            field=models.ForeignKey(related_name='prizes', blank=True, to='sprints.Prize', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/reclama/sprints/models.py
+++ b/reclama/sprints/models.py
@@ -42,7 +42,8 @@ class Bug(models.Model):
     """Bug model."""
     number = models.PositiveIntegerField()
     event = models.ManyToManyField(Event, related_name='bugs')
-    prize = models.ForeignKey(Prize, related_name='prizes')
+    prize = models.ForeignKey(Prize, related_name='prizes',
+                              null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
     def __unicode__(self):

--- a/reclama/templates/bugs.html
+++ b/reclama/templates/bugs.html
@@ -52,10 +52,12 @@
           </h3>
           <div id="m{{ b.number }}" class="bug-modified"></div>
         </div>
-        <div class="bug-prize"
-             title="If you have fixed this bug before the end of the event, please come by the Mozilla booth to pick up your prize.">
-          Prize: {{ b.prize }}
-        </div>
+        {% if b.prize %}
+          <div class="bug-prize"
+               title="If you have fixed this bug before the end of the event, please come by the Mozilla booth to pick up your prize.">
+            Prize: {{ b.prize }}
+          </div>
+        {% endif %}
       </div>
     </div>
   {% endfor %}


### PR DESCRIPTION
Prizes are nice, but not every event can really afford to hand them out.
Let's make them optional.

It'd be great if we could make use of this for https://mozweekend.de/ on the 12th, and for the buglist preps leading up to that.

cc @MichaelKohler
